### PR TITLE
fix: skip existing qdrant embeddings

### DIFF
--- a/Morlana_backend/App/Database/qdrant.py
+++ b/Morlana_backend/App/Database/qdrant.py
@@ -89,9 +89,12 @@ def add_embeddings(
     texts: List[str],
     ids: List[str],
     payloads: List[Dict[str, Any]],
-) -> None:
+) -> int:
     """
     Add embeddings to the Qdrant database.
+
+    Existing point IDs are checked before vectorization so previously ingested
+    posts do not get embedded again.
 
     Args:
         collection_name (str): The name of the Qdrant collection.
@@ -100,24 +103,25 @@ def add_embeddings(
         payloads (List[Dict[str, Any]]): List of payloads associated with each text.
 
     Returns:
-        None
+        int: Number of new embeddings inserted.
     """
-    vectors = [vectorize_text(text) for text in texts]
     points = []
 
-    for id_value, vector, payload in zip(ids, vectors, payloads):
-        # Check if the point ID already exists
+    for id_value, text, payload in zip(ids, texts, payloads):
         existing = CLIENT.retrieve(collection_name=collection_name, ids=[id_value])
 
-        if existing:  # If the list is not empty, the ID exists
+        if existing:
             print(f"ID {id_value} already exists in the collection. Skipping.")
-            return None
+            continue
 
+        vector = vectorize_text(text)
         point = PointStruct(id=id_value, vector=vector, payload=payload)
         points.append(point)
 
     if points:
         CLIENT.upsert(collection_name=collection_name, points=points)
+
+    return len(points)
 
 
 def delete_entries(collection_name: str, ids: List[int]) -> None:

--- a/Morlana_backend/tests/test_qdrant.py
+++ b/Morlana_backend/tests/test_qdrant.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+import App.Database.qdrant as qdrant
+
+
+def test_add_embeddings_skips_existing_points_before_vectorizing(monkeypatch):
+    client = Mock()
+    client.retrieve.side_effect = [[{"id": "existing-id"}], []]
+    monkeypatch.setattr(qdrant, "CLIENT", client)
+
+    vectorize_text = Mock(return_value=[0.1, 0.2, 0.3])
+    monkeypatch.setattr(qdrant, "vectorize_text", vectorize_text)
+
+    inserted_count = qdrant.add_embeddings(
+        collection_name="posts",
+        texts=["already embedded", "new post"],
+        ids=["existing-id", "new-id"],
+        payloads=[{"title": "old"}, {"title": "new"}],
+    )
+
+    assert inserted_count == 1
+    vectorize_text.assert_called_once_with("new post")
+    client.upsert.assert_called_once()
+
+    points = client.upsert.call_args.kwargs["points"]
+    assert len(points) == 1
+    assert points[0].id == "new-id"
+    assert points[0].payload == {"title": "new"}
+
+
+def test_add_embeddings_does_not_upsert_when_all_points_exist(monkeypatch):
+    client = Mock()
+    client.retrieve.return_value = [{"id": "existing-id"}]
+    monkeypatch.setattr(qdrant, "CLIENT", client)
+
+    vectorize_text = Mock(return_value=[0.1, 0.2, 0.3])
+    monkeypatch.setattr(qdrant, "vectorize_text", vectorize_text)
+
+    inserted_count = qdrant.add_embeddings(
+        collection_name="posts",
+        texts=["already embedded"],
+        ids=["existing-id"],
+        payloads=[{"title": "old"}],
+    )
+
+    assert inserted_count == 0
+    vectorize_text.assert_not_called()
+    client.upsert.assert_not_called()


### PR DESCRIPTION
## Summary
- Check existing Qdrant point IDs before generating embeddings
- Continue processing the rest of the batch when one ID already exists
- Return the number of newly inserted embeddings
- Add tests covering duplicate-skip behavior and all-existing batches

## Test Plan
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_qdrant.py`

Closes #6
